### PR TITLE
Disable OpenJ9 XL Specs

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,19 +1,13 @@
 targetConfigurations = [
         "x64Mac"        : [	"hotspot",	"openj9"					],
-        "x64MacXL"      : [			"openj9"					],
         "x64Linux"      : [	"hotspot",	"openj9",	"dragonwell",	"corretto"	],
         "x64Windows"    : [	"hotspot",	"openj9",	"dragonwell"			],
-        "x64WindowsXL"  : [			"openj9"					],
         "x32Windows"    : [	"hotspot"							],
         "ppc64Aix"      : [	"hotspot",	"openj9"					],
         "ppc64leLinux"  : [	"hotspot",	"openj9"					],
         "s390xLinux"    : [	"hotspot",	"openj9"					],
         "aarch64Linux"  : [	"hotspot",	"openj9",	"dragonwell"			],
         "arm32Linux"    : [	"hotspot"							],
-        "x64LinuxXL"    : [			"openj9"					],
-        "s390xLinuxXL"  : [			"openj9"					],
-        "ppc64leLinuxXL": [			"openj9"					],
-        "aarch64LinuxXL": [			"openj9"					],
         "riscv64Linux"  : [			"openj9"					]
 ]
 

--- a/pipelines/jobs/configurations/jdk16.groovy
+++ b/pipelines/jobs/configurations/jdk16.groovy
@@ -3,14 +3,8 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "x64MacXL"    : [
-                "openj9"
-        ],
         "x64Linux"    : [
                 "hotspot",
-                "openj9"
-        ],
-        "x64LinuxXL"  : [
                 "openj9"
         ],
         "x64AlpineLinux" : [
@@ -18,9 +12,6 @@ targetConfigurations = [
         ],
         "x64Windows"  : [
                 "hotspot",
-                "openj9"
-        ],
-        "x64WindowsXL": [
                 "openj9"
         ],
         "x32Windows"  : [
@@ -34,21 +25,12 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "ppc64leLinuxXL": [
-                "openj9"
-        ],
         "s390xLinux"  : [
                 "hotspot",
                 "openj9"
         ],
-        "s390xLinuxXL"  : [
-                "openj9"
-        ],
         "aarch64Linux": [
                 "hotspot",
-                "openj9"
-        ],
-        "aarch64LinuxXL": [
                 "openj9"
         ],
         "arm32Linux"  : [

--- a/pipelines/jobs/configurations/jdk17.groovy
+++ b/pipelines/jobs/configurations/jdk17.groovy
@@ -3,14 +3,8 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "x64MacXL"    : [
-                "openj9"
-        ],
         "x64Linux"    : [
                 "hotspot",
-                "openj9"
-        ],
-        "x64LinuxXL"  : [
                 "openj9"
         ],
         "x64AlpineLinux" : [
@@ -18,9 +12,6 @@ targetConfigurations = [
         ],
         "x64Windows"  : [
                 "hotspot",
-                "openj9"
-        ],
-        "x64WindowsXL": [
                 "openj9"
         ],
         "x32Windows"  : [
@@ -34,21 +25,12 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "ppc64leLinuxXL": [
-                "openj9"
-        ],
         "s390xLinux"  : [
                 "hotspot",
                 "openj9"
         ],
-        "s390xLinuxXL"  : [
-                "openj9"
-        ],
         "aarch64Linux": [
                 "hotspot",
-                "openj9"
-        ],
-        "aarch64LinuxXL": [
                 "openj9"
         ],
         "arm32Linux"  : [

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -18,9 +18,6 @@ targetConfigurations = [
                 "openj9",
                 "dragonwell"
         ],
-        "x64WindowsXL"  : [
-                "openj9"
-        ],
         "ppc64Aix"      : [
                 "hotspot",
                 "openj9"
@@ -43,18 +40,6 @@ targetConfigurations = [
         ],
         "sparcv9Solaris": [
                 "hotspot"
-        ],
-        "x64LinuxXL"       : [
-                "openj9"
-        ],
-        "s390xLinuxXL"       : [
-                "openj9"
-        ],
-        "ppc64leLinuxXL"       : [
-                "openj9"
-        ],
-        "x64MacXL"      : [
-                "openj9"
         ]
 ]
 


### PR DESCRIPTION
Turn off large heap platforms in the ci builds.
More cleanup can be done related to xl packages
once the dust settles.

Depends #22

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>