### PR TITLE
Update automated PR comment to link to pipeline tests doc

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -15,4 +15,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Thank you for creating a pull request!
-            In order to run the [pipeline tests](https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/tree/master/pipelines/build/prTester#openjdk-build-pr-tester) I require an admin to post the following comment: `run tests`
+            In order to run the [pipeline tests](pipelines/build/prTester#openjdk-build-pr-tester) I require an admin to post the following comment: `run tests`

--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -15,4 +15,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Thank you for creating a pull request!
-            In order to run the pipeline tests I require an admin to post the following comment: `run tests`
+            In order to run the [pipeline tests](https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/tree/master/pipelines/build/prTester#openjdk-build-pr-tester) I require an admin to post the following comment: `run tests`

--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -15,4 +15,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Thank you for creating a pull request!
-            In order to run the [pipeline tests](pipelines/build/prTester#openjdk-build-pr-tester) I require an admin to post the following comment: `run tests`
+            In order to run the [pipeline tests](https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/tree/master/pipelines/build/prTester#openjdk-build-pr-tester) I require an admin to post the following comment: `run tests`


### PR DESCRIPTION
I believe markdown links are valid in the templates, therefore including a link to the detailed docs on what the automatic comment refers to is useful for education new people in the project.

Signed-off-by: Stewart X Addison <sxa@redhat.com>