### PR TITLE
Reformat pipeline.json to make it simpler in the UI

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,63 +1,20 @@
 targetConfigurations = [
-        "x64Mac"      : [
-                "hotspot",
-                "openj9"
-        ],
-        "x64MacXL"    : [
-                "openj9"
-        ],
-        "x64Linux"    : [
-                "hotspot",
-                "openj9",
-                "corretto",
-                "dragonwell"
-        ],
-        "x64Windows"  : [
-                "hotspot",
-                "openj9",
-                "dragonwell"
-        ],
-        "x64WindowsXL"  : [
-                "openj9"
-        ],
-        "x32Windows"  : [
-                "hotspot"
-        ],
-        "ppc64Aix"    : [
-                "hotspot",
-                "openj9"
-        ],
-        "ppc64leLinux": [
-                "hotspot",
-                "openj9"
-        ],
-        "s390xLinux"  : [
-                "hotspot",
-                "openj9"
-        ],
-        "aarch64Linux": [
-                "hotspot",
-                "openj9",
-                "dragonwell"
-        ],
-        "arm32Linux"  : [
-                "hotspot"
-        ],
-        "x64LinuxXL"     : [
-                "openj9"
-        ],
-        "s390xLinuxXL"     : [
-                "openj9"
-        ],
-        "ppc64leLinuxXL"     : [
-                "openj9"
-        ],
-        "aarch64LinuxXL": [
-                "openj9"
-        ],
-        "riscv64Linux": [
-                "openj9"
-        ]
+        "x64Mac"        : [	"hotspot",	"openj9"					],
+        "x64MacXL"      : [			"openj9"					],
+        "x64Linux"      : [	"hotspot",	"openj9",	"dragonwell",	"corretto"	],
+        "x64Windows"    : [	"hotspot",	"openj9",	"dragonwell"			],
+        "x64WindowsXL"  : [			"openj9"					],
+        "x32Windows"    : [	"hotspot"							],
+        "ppc64Aix"      : [	"hotspot",	"openj9"					],
+        "ppc64leLinux"  : [	"hotspot",	"openj9"					],
+        "s390xLinux"    : [	"hotspot",	"openj9"					],
+        "aarch64Linux"  : [	"hotspot",	"openj9",	"dragonwell"			],
+        "arm32Linux"    : [	"hotspot"							],
+        "x64LinuxXL"    : [			"openj9"					],
+        "s390xLinuxXL"  : [			"openj9"					],
+        "ppc64leLinuxXL": [			"openj9"					],
+        "aarch64LinuxXL": [			"openj9"					],
+        "riscv64Linux"  : [			"openj9"					]
 ]
 
 // 18:05 Tue, Thur


### PR DESCRIPTION
Rework of https://github.com/AdoptOpenJDK/openjdk-build/pull/2394 which makes it easier to read the JSON in the jenkins UI when you want to add/remove variants - JDK11 only for now to verify if it works well, then we can do the same for other releases

Signed-off-by: Stewart X Addison <sxa@redhat.com>