### PR TITLE
Set lightweight checkout in DSLs

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -24,6 +24,11 @@ String buildFolder = "$JOB_FOLDER"
 if (!binding.hasVariable('GIT_URL')) GIT_URL = "https://github.com/AdoptOpenJDK/ci-jenkins-pipelines.git"
 if (!binding.hasVariable('GIT_BRANCH')) GIT_BRANCH = "master"
 
+isLightweight = true
+if (binding.hasVariable('PR_BUILDER')) {
+    isLightweight = false
+}
+
 folder(buildFolder) {
     description 'Automatically generated build jobs.'
 }
@@ -47,6 +52,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 }
             }
             scriptPath("${SCRIPT_PATH}")
+            lightweight(isLightweight)
         }
     }
     properties {

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -7,6 +7,7 @@ runInstaller = true
 runSigner = true
 cleanWsBuildOutput = true
 jdkVersion = "${JAVA_VERSION}"
+isLightweight = true
 
 // if true means this is running in the pr builder pipeline
 if (binding.hasVariable('PR_BUILDER')) {
@@ -16,6 +17,7 @@ if (binding.hasVariable('PR_BUILDER')) {
     runTests = false
     runInstaller = false
     runSigner = false
+    isLightweight = false
 }
 
 if (!binding.hasVariable('disableJob')) {
@@ -40,6 +42,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
                 }
             }
             scriptPath(SCRIPT)
+            lightweight(isLightweight)
         }
     }
     disabled(disableJob)

--- a/pipelines/jobs/weekly_release_pipeline_job_template.groovy
+++ b/pipelines/jobs/weekly_release_pipeline_job_template.groovy
@@ -16,6 +16,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
                 }
             }
             scriptPath(SCRIPT)
+            lightweight(true)
         }
     }
     disabled(disableJob)


### PR DESCRIPTION
Lightweight checkout avoids a full clone
on the master node unnecessarily.
Don't lightweight on PR tests as we need
to fetch the non-standard refspec.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

The first clone, defined in the job config scm section, will checkout to $WORKSPACE@script. The first step that runs in the pipelines is on Master and does a full checkout to $WORKSPACE. This leaves 2 full copies of the repo on disk. I have tried lightweight on my farm and it doesn't seem to break any functionality but I would appreciate a review from someone closer to the Adopt code. Lightweight will pull the single pipeline script file through a different mechanism other than the traditional clone. This is both faster and leaves a smaller footprint.

Note: This will require script approvals if you don't have DSL script security disabled.