### PR TITLE
build: re enable win aarch64 builds

### DIFF
--- a/pipelines/jobs/configurations/jdk16.groovy
+++ b/pipelines/jobs/configurations/jdk16.groovy
@@ -17,6 +17,9 @@ targetConfigurations = [
         "x32Windows"  : [
                 "hotspot"
         ],
+        "aarch64Windows"  : [
+                "hotspot"
+        ],
         "ppc64Aix"    : [
                 "hotspot",
                 "openj9"

--- a/pipelines/jobs/configurations/jdk17.groovy
+++ b/pipelines/jobs/configurations/jdk17.groovy
@@ -17,6 +17,9 @@ targetConfigurations = [
         "x32Windows"  : [
                 "hotspot"
         ],
+        "aarch64Windows"  : [
+                "hotspot"
+        ],
         "ppc64Aix"    : [
                 "hotspot",
                 "openj9"


### PR DESCRIPTION
Was temporarily disabled until https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1884 was completed