### PR TITLE
stop requiring mingw labels on Openj9 JDK8+11 builds

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -63,10 +63,7 @@ class Config11 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: [
-                        hotspot: 'win2012',
-                        openj9:  'win2012&&mingw-standalone'
-                ],
+                additionalNodeLabels: 'win2012',
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -38,19 +38,14 @@ class Config8 {
         x64Windows    : [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: [
-                        hotspot : 'win2012',
-                        corretto: 'win2012',
-                        openj9  : 'win2012&&mingw-cygwin',
-                        dragonwell: 'win2012'
-                ],
+                additionalNodeLabels: 'win2012',
                 test                 : 'default'
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
-                additionalNodeLabels : 'win2012&&mingw-cygwin',
+                additionalNodeLabels : 'win2012',
                 test                 : 'default',
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
@@ -59,11 +54,7 @@ class Config8 {
         x32Windows    : [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: [
-                        hotspot : 'win2012',
-                        corretto: 'win2012',
-                        openj9  : 'win2012&&mingw-cygwin'
-                ],
+                additionalNodeLabels: 'win2012',
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],


### PR DESCRIPTION
Based on https://github.com/AdoptOpenJDK/openjdk-build/issues/700 and the checks in https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/issues/66#issuecomment-790548381 I think the tags are historic and no longer necessary as all bulid machines are set up the same way and the OpenJ9 builds no longer require special treatment (In fact 15+ do not have this tag).

@pshipton I presume you are not aware of any reason to keep `mingw` labels on the OpenJ9 builds to tie it to the IBM Cloud (SoftLayer) build machines we have?

Signed-off-by: Stewart X Addison <sxa@redhat.com>