### PR TITLE
Re-enable testList as PR 85 removed it preventing testing

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -251,6 +251,8 @@ class Build {
 
         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
 
+        testList = buildConfig.TEST_LIST
+
         testList.each { testType ->
 
             // For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job


### PR DESCRIPTION
Removed by https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/pull/85/files - seemed to remove the `testList` definition entirely

Signed-off-by: Stewart X Addison <sxa@redhat.com>