### PR TITLE
Inhibit nightly testing during JDK16 release cycle

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -387,7 +387,7 @@ class Regeneration implements Serializable {
                 RELEASE: false,
                 PUBLISH_NAME: "",
                 ADOPT_BUILD_NUMBER: "",
-                ENABLE_TESTS: true,
+                ENABLE_TESTS: false,
                 ENABLE_INSTALLERS: true,
                 ENABLE_SIGNER: true,
                 CLEAN_WORKSPACE: true,

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -2,7 +2,7 @@ import groovy.json.JsonOutput
 
 gitRefSpec = ""
 propagateFailures = false
-runTests = true
+runTests = false
 runInstaller = true
 runSigner = true
 cleanWsBuildOutput = true


### PR DESCRIPTION
Title says it all - part of the standard release process.

Signed-off-by: Stewart X Addison <sxa@redhat.com>