### PR TITLE
Re-enable nightly testing since the JDK16 GA have been pushed to github

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -387,7 +387,7 @@ class Regeneration implements Serializable {
                 RELEASE: false,
                 PUBLISH_NAME: "",
                 ADOPT_BUILD_NUMBER: "",
-                ENABLE_TESTS: false,
+                ENABLE_TESTS: true,
                 ENABLE_INSTALLERS: true,
                 ENABLE_SIGNER: true,
                 CLEAN_WORKSPACE: true,

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -2,7 +2,7 @@ import groovy.json.JsonOutput
 
 gitRefSpec = ""
 propagateFailures = false
-runTests = false
+runTests = true
 runInstaller = true
 runSigner = true
 cleanWsBuildOutput = true


### PR DESCRIPTION
Description is self-explanatory - this reverts last week's commit