### PR TITLE
Remove aarch64Windows from nightly builds

### DIFF
--- a/pipelines/jobs/configurations/jdk16.groovy
+++ b/pipelines/jobs/configurations/jdk16.groovy
@@ -17,9 +17,6 @@ targetConfigurations = [
         "x32Windows"  : [
                 "hotspot"
         ],
-        "aarch64Windows"  : [
-                "hotspot"
-        ],
         "ppc64Aix"    : [
                 "hotspot",
                 "openj9"

--- a/pipelines/jobs/configurations/jdk17.groovy
+++ b/pipelines/jobs/configurations/jdk17.groovy
@@ -17,9 +17,6 @@ targetConfigurations = [
         "x32Windows"  : [
                 "hotspot"
         ],
-        "aarch64Windows"  : [
-                "hotspot"
-        ],
         "ppc64Aix"    : [
                 "hotspot",
                 "openj9"


### PR DESCRIPTION
Until aarch64Windows builds have been fully stabilized remove them from nightly runs.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>