### PR TITLE
Always pull Docker image

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1230,6 +1230,15 @@ class Build {
 
                             }
 
+                            // Pull the docker image from DockerHub
+                            try {
+                                context.timeout(time: buildTimeouts.DOCKER_PULL_TIMEOUT, unit: "HOURS") {
+                                    context.docker.image(buildConfig.DOCKER_IMAGE).pull()
+                                }
+                            } catch (FlowInterruptedException e) {
+                                throw new Exception("[ERROR] Master docker image pull timeout (${buildTimeouts.DOCKER_PULL_TIMEOUT} HOURS) has been reached. Exiting...")
+                            }
+
                             // Use our docker file if DOCKER_FILE is defined
                             if (buildConfig.DOCKER_FILE) {
                                 try {
@@ -1255,15 +1264,7 @@ class Build {
                                     )
                                 }
 
-                            // Otherwise, pull the docker image from DockerHub
                             } else {
-                                try {
-                                    context.timeout(time: buildTimeouts.DOCKER_PULL_TIMEOUT, unit: "HOURS") {
-                                        context.docker.image(buildConfig.DOCKER_IMAGE).pull()
-                                    }
-                                } catch (FlowInterruptedException e) {
-                                    throw new Exception("[ERROR] Master docker image pull timeout (${buildTimeouts.DOCKER_PULL_TIMEOUT} HOURS) has been reached. Exiting...")
-                                }
 
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside {
                                     buildScripts(


### PR DESCRIPTION
Existing behaviour is to only pull DOCKER_IMAGE when
using the image as is. If the DOCKER_FILE path is
traversed, the base DOCKER_IMAGE is not refreshed
if it exists on the system. Fix is to move the pull
before the 'if' so that it is run for both cases.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>