### PR TITLE
Fix syntax error 'done' in mac installer step

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -546,7 +546,7 @@ class Build {
         context.node('master') {
             context.stage("installer") {
                 switch (buildConfig.TARGET_OS) {
-                    case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt; done'; buildMacInstaller(versionData); break
+                    case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt'; buildMacInstaller(versionData); break
                     case "linux": buildLinuxInstaller(versionData); break
                     case "windows": buildWindowsInstaller(versionData); break
                     default: break


### PR DESCRIPTION
Looks like it was maybe a copy-paste mishap. Not sure why this doesn't fail at Adopt
but it fails on my builds.

Introduced by https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/commit/9537297119aa13bc1a2a9e86ebf550b0428c93f6

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>