### PR TITLE
Null safety check sleepTime

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -29,7 +29,7 @@ class Regeneration implements Serializable {
     private final Map<String, ?> targetConfigurations
     private final Map<String, ?> DEFAULTS_JSON
     private final Map<String, ?> excludedBuilds
-    private final Integer sleepTime
+    private Integer sleepTime
     private final def currentBuild
     private final def context
 

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -600,7 +600,7 @@ class Regeneration implements Serializable {
                                 }
 
                                 if (inProgress) {
-                                    // Null safety check sleep as sleeping null/forever is possible
+                                    // Null safety check sleep as sleeping null may cause jenkins DoS
                                     if (!sleepTime) {
                                         sleepTime = 900
                                     }

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -600,6 +600,10 @@ class Regeneration implements Serializable {
                                 }
 
                                 if (inProgress) {
+                                    // Null safety check sleep as sleeping null/forever is possible
+                                    if (!sleepTime) {
+                                        sleepTime = 900
+                                    }
                                     // Sleep for a bit, then check again...
                                     context.println "[INFO] ${pipeline} is running. Sleeping for ${sleepTime} seconds while waiting for ${pipeline} to complete..."
 


### PR DESCRIPTION
Recent jenkins instability could be due to regenerators sleeping forever and generating too many logs.
This ensures sleepTime is always set (along with #112) and does not sleep forever

Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>